### PR TITLE
[#IOPLT-325] Add Flatten Mapping and refactor enrichment

### DIFF
--- a/src/enrichment/__tests__/table.test.ts
+++ b/src/enrichment/__tests__/table.test.ts
@@ -91,4 +91,17 @@ describe("tableEnrich", () => {
       )
     )();
   });
+
+  it("should return flattened enriched input if table document is found and output field name is not provided", async () => {
+    getTableDocumentMock.mockImplementationOnce(() =>
+      TE.right(O.some({ baz: "baz" }))
+    );
+    await pipe(
+      tableEnrich(input, tableClientMock, "partitionKey", "rowKey"),
+      TE.bimap(
+        () => fail("it should not fail"),
+        result => expect(result).toEqual({ ...input, baz: "baz" })
+      )
+    )();
+  });
 });

--- a/src/enrichment/blob.ts
+++ b/src/enrichment/blob.ts
@@ -6,6 +6,7 @@ import * as BS from "@azure/storage-blob";
 import { errorsToReadableMessages } from "@pagopa/ts-commons/lib/reporters";
 
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { flattenField } from "../formatter/flatten";
 import { getBlobDocument } from "../utils/blobStorage";
 import { NotInKeys } from "../utils/types";
 import { toJsonObject } from "../utils/data";
@@ -36,10 +37,17 @@ export const blobEnrich = <T, K extends string>(
             outputFieldName,
             O.fromNullable,
             O.map(fieldName => ({ ...input, [fieldName]: blobDocumentObject })),
-            O.getOrElseW(() => ({
-              ...input,
-              ...blobDocumentObject
-            }))
+            O.getOrElseW(() =>
+              pipe(`${String(blobNameField)}_enrich`, flattenFieldName =>
+                flattenField(
+                  {
+                    ...input,
+                    [flattenFieldName]: blobDocumentObject
+                  },
+                  flattenFieldName
+                )
+              )
+            )
           )
         ),
         O.getOrElse(() => input)

--- a/src/formatter/__test__/flatten.test.ts
+++ b/src/formatter/__test__/flatten.test.ts
@@ -1,0 +1,51 @@
+import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
+import { flattenField } from "../flatten";
+
+const aNormalizedField = {
+  bar: 1,
+  baz: false
+};
+
+const aNormalizedFieldWithAlreadyExistingProperty = {
+  ...aNormalizedField,
+  foo: "normalized_foo"
+};
+
+const input = {
+  foo: "foo",
+  normalized: aNormalizedField
+};
+
+const anotherInput = {
+  ...input,
+  normalized: aNormalizedFieldWithAlreadyExistingProperty
+};
+describe("flattenField", () => {
+  it("should return unmodified input if fieldToFlat is not an Object", () => {
+    const result = flattenField(input, "foo");
+    expect(result).toEqual(input);
+  });
+
+  it("should return a flattened input without renaming any field", () => {
+    const result = flattenField(input, "normalized");
+    expect(result).toEqual(
+      withoutUndefinedValues({
+        ...input,
+        normalized: undefined,
+        ...aNormalizedField
+      })
+    );
+  });
+
+  it("should return a flattened input with renaming fields that overlap existing input fields", () => {
+    const result = flattenField(anotherInput, "normalized");
+    expect(result).toEqual(
+      withoutUndefinedValues({
+        ...aNormalizedFieldWithAlreadyExistingProperty,
+        ...anotherInput,
+        normalized: undefined,
+        normalized_foo: aNormalizedFieldWithAlreadyExistingProperty.foo
+      })
+    );
+  });
+});

--- a/src/formatter/flatten.ts
+++ b/src/formatter/flatten.ts
@@ -1,0 +1,37 @@
+import * as O from "fp-ts/Option";
+import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
+import { pipe } from "fp-ts/lib/function";
+import { toJsonObject } from "../utils/data";
+
+export const flattenField = <T>(input: T, fieldToFlat: keyof T): T =>
+  pipe(
+    input,
+    O.fromPredicate(stream => stream[fieldToFlat] instanceof Object),
+    O.map(data => pipe(data[fieldToFlat], toJsonObject)),
+    O.map(objToFlat =>
+      pipe(
+        objToFlat,
+        Object.keys,
+        objectFieldNames =>
+          objectFieldNames.reduce(
+            (acc, fieldName) =>
+              Object.keys(input).includes(fieldName)
+                ? {
+                    ...acc,
+                    [`${String(fieldToFlat)}_${fieldName}`]: objToFlat[
+                      fieldName
+                    ]
+                  }
+                : { ...acc, [fieldName]: objToFlat[fieldName] },
+            {}
+          ),
+        flattenedContent => ({ ...input, ...flattenedContent }),
+        result =>
+          withoutUndefinedValues({
+            ...result,
+            [fieldToFlat]: undefined
+          })
+      )
+    ),
+    O.getOrElse(() => input)
+  );

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,5 +1,4 @@
-import * as J from "fp-ts/lib/Json";
 import * as R from "fp-ts/Record";
 
-export const toJsonObject = (jsonData: J.Json): Record<string, unknown> =>
+export const toJsonObject = (jsonData: unknown): Record<string, unknown> =>
   R.fromEntries(Object.entries(jsonData));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- add `flattenField` mapping
- add flatten unit tests
- Refactor `blob` enrichment
- Refactor `table` enrichment
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required to allow denormalization in specific use cases when data stream is composed by sub-objects that can be flattened. If flatten occurs field names are renamed if original name overlaps with other existing properties
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
